### PR TITLE
Fix memmove copy index when buffers overlap

### DIFF
--- a/libs/libc/memmove.c
+++ b/libs/libc/memmove.c
@@ -8,7 +8,7 @@ void *memmove(void *dest, const void *src, size_t n)
 
 	if (s < d && s + n > d) {
 		while (n-- > 0)
-			d[n - 1] = s[n - 1];
+			d[n] = s[n];
 		return dest;
 	}
 


### PR DESCRIPTION
Hello,

I believe the current implementation of `/libs/libc/memmove.c` doesn't behave as expected when buffers overlap. Here's an example with these functions extracted:
```c
#include <stdio.h>

void *kmemcpy(void *dest, const void *src, size_t n) {
  const char *s = src;
  char *d = dest;

  for (size_t i = 0; i < n; i++)
    *d++ = *s++;

  return dest;
}

void *kmemmove(void *dest, const void *src, size_t n) {
  char *d = dest;
  const char *s = src;

  if (s < d && s + n > d) {
    while (n-- > 0) {
      d[n - 1] = s[n - 1];
    }
    return dest;
  }

  return kmemcpy(dest, src, n);
}

int main() {
  char buffer[] = {'H', 'e', 'l', 'l', 'o', '!', '?', 0};
  char *dest = buffer + 2;
  printf("%.*s\n", 5, buffer);
  kmemmove(dest, buffer, 5);
  printf("%.*s\n", 5, dest);
}
```
Output:
```shell
> gcc test.c && ./a.out
Hello
Hell?
```
With Asan:
```shell
> gcc -fsanitize=address test.c && ./a.out
Hello
=================================================================
==339006==ERROR: AddressSanitizer: stack-buffer-underflow on address 0x7fff925ed1ef at pc 0x55cca4d3633f bp 0x7fff925ed170 sp 0x7fff925ed160
READ of size 1 at 0x7fff925ed1ef thread T0
    #0 0x55cca4d3633e in kmemmove (/tmp/a.out+0x133e)
...
```

I believe these two issues are caused by the line:
```c
d[n - 1] = s[n - 1];
```
The index is shifted by one causing the last byte of the buffer to be ignored, and a byte to be copied before the buffer, triggering the buffer underflow error.

Indexing with `n` instead of `n - 1` solves these two issues.